### PR TITLE
Create docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM openresty/openresty:latest-xenial
-RUN apt-get update -qq && apt-get install -qqy libssl-dev
-RUN /usr/local/openresty/luajit/bin/luarocks install lapis && \
+RUN apt-get update -qq && apt-get install -qqy libssl-dev git
+RUN /usr/local/openresty/luajit/bin/luarocks install lapis 1.5.1-1 && \
+/usr/local/openresty/luajit/bin/luarocks install lapis-console && \
 /usr/local/openresty/luajit/bin/luarocks install penlight && \
-/usr/local/openresty/luajit/bin/luarocks install inspect
+/usr/local/openresty/luajit/bin/luarocks install inspect && \
+/usr/local/openresty/luajit/bin/luarocks install datafile && \
+/usr/local/openresty/luajit/bin/luarocks install https://raw.githubusercontent.com/vadi2/fhir-formats/master/fhirformats-0.1.0-1.rockspec
+COPY . /opt/dryfhir
+VOLUME /opt/dryfhir
+WORKDIR /opt/dryfhir
+ENTRYPOINT ["/usr/local/openresty/luajit/bin/lapis"]
+CMD ["server", "dockerdev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openresty/openresty:latest-xenial
+RUN apt-get update -qq && apt-get install -qqy libssl-dev
+RUN /usr/local/openresty/luajit/bin/luarocks install lapis && \
+/usr/local/openresty/luajit/bin/luarocks install penlight && \
+/usr/local/openresty/luajit/bin/luarocks install inspect

--- a/config.lua
+++ b/config.lua
@@ -22,14 +22,16 @@ config({"development", "heroku", "test", "prod"}, {
   postgres = {
     host = "127.0.0.1",
     user = "postgres",
-  }
+  },
+  resolver_string = ""
 })
 
 config({"dockerdev", "dockerprod"}, {
   postgres = {
     host = "db",
     user = "fhirbase",
-  }
+  },
+  resolver_string = "resolver 127.0.0.11;"
 })
 
 config("development", {

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 -- config.lua
 local config = require("lapis.config")
 
-config({"development", "heroku", "test", "prod"}, {
+config({"development", "heroku", "test", "prod", "dockerdev", "dockerprod"}, {
   email_enabled = false,
   secret = "not-set-yet",
   session_name = "dryfhir_session",
@@ -12,7 +12,7 @@ config({"development", "heroku", "test", "prod"}, {
   },
   postgres = {
     backend = "pgmoon",
-    host = "127.0.0.1",
+    host = "db",
     port = "5432",
     user = "postgres",
     database = "fhirbase",
@@ -22,6 +22,11 @@ config({"development", "heroku", "test", "prod"}, {
 
 config("development", {
   port = 8080,
+  print_stack_to_browser = true
+})
+
+config("dockerdev", {
+  port = 80,
   print_stack_to_browser = true
 })
 
@@ -39,7 +44,8 @@ config("test", {
   print_stack_to_browser = true
 })
 
-config("prod", {
+config({"prod", "dockerprod"}, {
+  port = 80,
   logging = {
     queries = false,
     requests = true
@@ -50,7 +56,7 @@ config("prod", {
 
 -- template responses
 
-config({"development", "heroku", "test", "prod"}, {
+config({"development", "heroku", "test", "prod", "dockerdev", "dockerprod"}, {
   canned_responses = {
     handle_404 = {
     {

--- a/config.lua
+++ b/config.lua
@@ -12,12 +12,24 @@ config({"development", "heroku", "test", "prod", "dockerdev", "dockerprod"}, {
   },
   postgres = {
     backend = "pgmoon",
-    host = "db",
     port = "5432",
-    user = "postgres",
     database = "fhirbase",
   },
   print_stack_to_browser = false
+})
+
+config({"development", "heroku", "test", "prod"}, {
+  postgres = {
+    host = "127.0.0.1",
+    user = "postgres",
+  }
+})
+
+config({"dockerdev", "dockerprod"}, {
+  postgres = {
+    host = "db",
+    user = "fhirbase",
+  }
 })
 
 config("development", {

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: "2"
+services:
+   dryfhir:
+      volumes:
+         - ".:/opt/dryfhir/"
+      ports:
+         - "8080:80"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,6 @@
+version: "2"
+services:
+   dryfhir:
+      ports:
+         - "80:80"
+      command: ["server", "dockerprod"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "2"
+volumes:
+   data:
+services:
+   db:
+      image: dryfhir/fhirbase-postgres-plv8:latest
+      volumes:
+         - "data:/var/lib/postgresql/data"
+   dryfhir:
+      image: dryfhir/dryfhir:latest
+      links:
+         - db

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,8 @@ events {
 http {
   include mime.types;
 
+  ${{RESOLVER_STRING}}
+
   # pre-load list of fhir-supported resources so it's available to lapis before starting
   # not done inside lapis as lapis doesn't support running functions before `return app'
 


### PR DESCRIPTION
This PR adds everything needed to use docker for dryFHIR releases and as a development environment.

I needed to change the config a little because docker spreads tasks between machines, so I needed a database machine and a web server machine. And since Nginx doesn't resolve hostnames via "normal" means, I also needed to add a resolver IP. `127.0.0.11` is the docker resolver. But I hope the config works for all other existing environments as it was before.

So how does the docker stuff work?

The Dockerfile builds an image with all dependencies and the dryFHIR code at /opt/dryfhir and is set to start the lapis server with the `dockerdev` environment by default. You can use other environments (like `dockerprod`) with `docker run <options> server <environment>`.

For the ease of starting the docker machines in a usual state, I added two docker-compose setups as well, one for development (the default) and one for production.

For development, the `docker-compose up` command starts the database server and the web server within the same network and linked, so that they can access each other. The `docker-compose.yml` and `docker-compose.orverride.yml` are used automatically. The web server will be reachable at `localhost:8080` and it will have the current directory mounted `/opt/dryfhir`, overriding the original content (the stable, released version). That way, code changes are immediately reflected on the server.

For production, you can use docker-compose as well with `docker-compose -f docker-compose.yml -f docker-compose.prod.yml up`. This will ignore the override file and use the production file instead, where `/opt/dryfhir` is not overwritten and the published port is 80 (which you may change editing the prod file).

The last interesting bit is, that docker-compose can be used to create a definition of a release of multiple connected docker-images. By useing `docker.compose -f docker-compose.yml -f docker-compose.prod.yml bundle`, a json file is generated, which contains the exact versions of both images at the time (you want to use docker-compose pull first). With that file, you can use `docker deploy` and be up and running without installing docker.compose on the prod machine.